### PR TITLE
Support libexec and lib64 paths for the webkitgtk helper

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,5 +38,5 @@ executable('obs-webkitgtk-helper',
         dependency('webkit2gtk-4.0'),
     ],
     install : true,
-    install_dir : join_paths(get_option('libdir'), 'obs-plugins'),
+    install_dir : join_paths(get_option('libexecdir'), 'obs-plugins'),
 )

--- a/obs-webkitgtk.c
+++ b/obs-webkitgtk.c
@@ -90,8 +90,22 @@ static void start(data_t *data)
 	gchar *path = g_file_read_link("/proc/self/exe", NULL);
 
 	gchar *app =
-		g_strdup_printf("%s/../lib/obs-plugins/obs-webkitgtk-helper",
+		g_strdup_printf("%s/../libexec/obs-plugins/obs-webkitgtk-helper",
 				g_path_get_dirname(path));
+
+	if (g_file_test(app, G_FILE_TEST_IS_EXECUTABLE) == FALSE) {
+		g_free(app);
+
+		app = g_strdup_printf("%s/../lib64/obs-plugins/obs-webkitgtk-helper",
+				      g_path_get_dirname(path));
+	}
+
+	if (g_file_test(app, G_FILE_TEST_IS_EXECUTABLE) == FALSE) {
+		g_free(app);
+
+		app = g_strdup_printf("%s/../lib/obs-plugins/obs-webkitgtk-helper",
+				      g_path_get_dirname(path));
+	}
 
 	if (g_file_test(app, G_FILE_TEST_IS_EXECUTABLE) == FALSE) {
 		g_free(app);


### PR DESCRIPTION
The helper should be installed in the libexec directory path, so we should default to that.

Additionally, support more permutations of libexec paths so that this is more likely to work out of the gate.