### PR TITLE
Fix the capitalization of the name of the browser engine

### DIFF
--- a/obs-webkitgtk.c
+++ b/obs-webkitgtk.c
@@ -36,7 +36,7 @@ typedef struct {
 
 static const char *get_name(void *type_data)
 {
-	return "WebkitGtk";
+	return "WebKitGTK";
 }
 
 static gpointer thread(gpointer user_data)


### PR DESCRIPTION
It's called "WebKitGTK" officially, so let's use that here.