### PR TITLE
Use webkit2gtk-4.1 API module

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ executable('obs-webkitgtk-helper',
     'obs-webkitgtk-helper.c',
     dependencies : [
         dependency('gtk+-3.0'),
-        dependency('webkit2gtk-4.0'),
+        dependency('webkit2gtk-4.1'),
     ],
     install : true,
     install_dir : join_paths(get_option('libexecdir'), 'obs-plugins'),


### PR DESCRIPTION
The webkit2gtk-4.0 API module links against libsoup2, which is no longer maintained and being actively removed from Linux distributions.

The webkit2gtk-4.1 API module links against the newer libsoup3 and remains fully API compatible otherwise.

Reference: https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version