### PR TITLE
Use 'Browser Source' plugin name to keep uniformity with OBS's window…

### DIFF
--- a/obs-webkitgtk.c
+++ b/obs-webkitgtk.c
@@ -36,7 +36,7 @@ typedef struct {
 
 static const char *get_name(void *type_data)
 {
-	return "WebKitGTK";
+	return "Browser Source (WebKitGTK)";
 }
 
 static gpointer thread(gpointer user_data)


### PR DESCRIPTION
…s version and easier user understanding.